### PR TITLE
Enable build of armhf for 32 bit RaspiOS

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         target_distro: [bookworm, trixie]
         target_arch: [arm64, armhf, amd64, i386]
-        exclude:
-          - target_arch: armhf  # No binutils-i686-linux-gnu :-(
       fail-fast: false
 
     runs-on: ${{ startsWith(matrix.target_arch, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -87,7 +85,7 @@ jobs:
           sudo chroot ${BDIR} /bin/bash -c "./build-insfdusr.sh ${TARGET_DISTRO} ${TARGET_ARCH}"
 
       - name: Upload packages as RaspiOS
-        if: matrix.target_arch == 'arm64'
+        if: matrix.target_arch == 'arm64' || matrix.target_arch == 'armhf'
         uses: actions/upload-artifact@v4
         with:
           name: RaspiOS-${{ matrix.target_distro }}-${{ matrix.target_arch }}

--- a/scripts/build-dj64dev.sh
+++ b/scripts/build-dj64dev.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+TARGET_DISTRO="$1"
+TARGET_ARCH="$2"
+
 set -e
 
 git clone https://github.com/stsp/dj64dev.git dj64dev.git
 (
   cd dj64dev.git
+  if [ "$TARGET_ARCH" = "armhf" ] ; then
+    sed -i 's/binutils-i686-linux-gnu/clang, llvm, lld/g' debian/control
+  fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   make deb
 )

--- a/scripts/build-dosemu2.sh
+++ b/scripts/build-dosemu2.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+TARGET_DISTRO="$1"
+TARGET_ARCH="$2"
+
 set -e
 
 git clone https://github.com/dosemu2/dosemu2.git dosemu2.git
 (
   cd dosemu2.git
+  if [ "$TARGET_ARCH" = "armhf" ] ; then
+    sed -i -e 's/binutils-i686-linux-gnu/llvm, lld/g' debian/control
+  fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   make deb
 )

--- a/scripts/build-fdpp.sh
+++ b/scripts/build-fdpp.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 
+TARGET_DISTRO="$1"
+TARGET_ARCH="$2"
+
 set -e
 
 git clone https://github.com/dosemu2/fdpp.git fdpp.git
 (
   cd fdpp.git
+  if [ "$TARGET_ARCH" = "armhf" ] ; then
+    sed -i -e 's/binutils-x86-64-linux-gnu/lld, llvm/g'\
+           -e 's/nasm-segelf/nasm/g' debian/control
+    sed -i -e 's/\bdh_auto_build\b/CROSS_LD=ld.lld USE_LTO=0 &/g' debian/rules
+  fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   ./build_deb.sh
 )

--- a/scripts/build-nasm-segelf.sh
+++ b/scripts/build-nasm-segelf.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+TARGET_DISTRO="$1"
+TARGET_ARCH="$2"
+
+if [ "${TARGET_ARCH}" = "armhf" ] ; then
+  echo "Don't need nasm-segelf when using ld.lld"
+ else
+
 git clone https://github.com/stsp/nasm-segelf.git nasm-segelf.git
 (
   cd nasm-segelf.git
@@ -12,4 +19,6 @@ git clone https://github.com/stsp/nasm-segelf.git nasm-segelf.git
 
 if [ "$(pwd)" = "/" ] ; then
 	sudo apt install -y -f ./nasm-segelf*.deb
+fi
+
 fi


### PR DESCRIPTION
Note: FDPP has an 8k DOS memory penalty for using ld.lld,
   so only use it for armhf.