### PR TITLE
Update for new fdpp, djstub, and dj64 packages

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -64,9 +64,9 @@ jobs:
         run: |
           sudo chroot ${BDIR} /bin/bash -c "./build-dj64dev.sh ${TARGET_DISTRO} ${TARGET_ARCH}"
 
-      - name: Nasm-segelf
-        run: |
-          sudo chroot ${BDIR} /bin/bash -c "./build-nasm-segelf.sh ${TARGET_DISTRO} ${TARGET_ARCH}"
+#      - name: Nasm-segelf
+#        run: |
+#          sudo chroot ${BDIR} /bin/bash -c "./build-nasm-segelf.sh ${TARGET_DISTRO} ${TARGET_ARCH}"
 
       - name: Fdpp
         run: |

--- a/scripts/build-comcom64.sh
+++ b/scripts/build-comcom64.sh
@@ -1,10 +1,22 @@
 #!/bin/sh
 
+TARGET_DISTRO="$1"
+TARGET_ARCH="$2"
+
 set -e
 
 git clone https://github.com/dosemu2/comcom64.git comcom64.git
 (
   cd comcom64.git
+  if [ "$TARGET_ARCH" = "armhf" ] ; then
+    sed -i -e 's/dj32-dev/bash/g' \
+           -e '/Package: comcom32/{n;s/Architecture: any/Architecture: amd64/;}' debian/control
+
+    sed -i -e 's/all: 64 32/all: 64/g' \
+           -e 's/install: install_64 install_32/install: install_64/g' makefile
+
+    rm -f debian/comcom32.install
+  fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   debian/rules build
   fakeroot debian/rules binary

--- a/scripts/build-dj64dev.sh
+++ b/scripts/build-dj64dev.sh
@@ -9,7 +9,11 @@ git clone https://github.com/stsp/dj64dev.git dj64dev.git
 (
   cd dj64dev.git
   if [ "$TARGET_ARCH" = "armhf" ] ; then
-    sed -i 's/binutils-i686-linux-gnu/clang, llvm, lld/g' debian/control
+    sed -i -e 's/gcc-i686-linux-gnu/bash/g' \
+           -e 's/binutils-i686-linux-gnu/clang, llvm, lld/g' \
+           -e '/Package: dj32-dev/{n;s/Architecture: any/Architecture: amd64/;}' debian/control
+
+    sed -i 's,--with-sysroot32=/usr/lib/${DEB_HOST_MULTIARCH}/i386-pc-dj32,--disable-32bit,g' debian/rules
   fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   make deb
@@ -18,5 +22,5 @@ git clone https://github.com/stsp/dj64dev.git dj64dev.git
 ls -ltr *.deb
 
 if [ "$(pwd)" = "/" ] ; then
-	sudo apt install -y -f ./dj*64*.deb
+	sudo apt install -y -f ./libdjdev*.deb ./libdjstub*.deb ./dj*.deb
 fi

--- a/scripts/build-djstub.sh
+++ b/scripts/build-djstub.sh
@@ -5,7 +5,7 @@ set -e
 TARGET_DISTRO="$1"
 TARGET_ARCH="$2"
 
-if [ "${TARGET_DISTRO}" = "trixie" ] ; then
+if [ "${TARGET_DISTRO}" = "somefuture" ] ; then
   echo "Version included in Debian is suitable"
 else
   git clone https://github.com/stsp/djstub.git djstub.git

--- a/scripts/build-fdpp.sh
+++ b/scripts/build-fdpp.sh
@@ -9,14 +9,16 @@ git clone https://github.com/dosemu2/fdpp.git fdpp.git
 (
   cd fdpp.git
   if [ "$TARGET_ARCH" = "armhf" ] ; then
-    sed -i -e 's/binutils-x86-64-linux-gnu/lld, llvm/g'\
-           -e 's/nasm-segelf/nasm/g' debian/control
+    sed -i -e 's/binutils-x86-64-linux-gnu/lld, llvm/g' debian/control
+
     sed -i -e 's/\bdh_auto_build\b/CROSS_LD=ld.lld USE_LTO=0 &/g' debian/rules
   fi
   mk-build-deps --install --root-cmd sudo --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
   ./build_deb.sh
 )
 
+ls -l *.deb
+
 if [ "$(pwd)" = "/" ] ; then
-	sudo apt install -y -f ./fdpp*.deb
+	sudo apt install -y -f ./libfd*35*.deb ./fdpp*.deb
 fi


### PR DESCRIPTION
Notes:

    1/ A little oddity, the libdjstub64-0 is not made by djstub,
       but instead by dj64dev.

    2/ Need to build 32 bit packages where possible, currently it's
       not possible on armhf.

    3/ No need to use nasm-segelf anymore.